### PR TITLE
replaced std::atof 

### DIFF
--- a/src/config/ConfigurationReader.cpp
+++ b/src/config/ConfigurationReader.cpp
@@ -45,6 +45,7 @@
 #include "config/LightSourcesConfig.h"
 
 #include "utils/RobogenUtils.h"
+#include "utils/ParsingUtils.h"
 
 #define DEFAULT_LIGHT_SOURCE_HEIGHT (0.1)
 #define DEFAULT_OBSTACLE_DENSITY (0.)
@@ -451,10 +452,10 @@ boost::shared_ptr<RobogenConfig> ConfigurationReader::parseConfigurationFile(
 		std::vector<std::string> gravityOpts;
 		boost::split(gravityOpts, gravityString, boost::is_any_of(","));
 		if (gravityOpts.size() == 1) {
-			gravity[2] = std::atof(gravityOpts[0].c_str());
+			gravity[2] = parse_float(gravityOpts[0]);
 		} else if (gravityOpts.size() == 3) {
 			for(unsigned int i=0; i<3; ++i) {
-				gravity[i] = std::atof(gravityOpts[i].c_str());
+				gravity[i] = parse_float(gravityOpts[i]);
 			}
 		} else {
 			std::cerr << "'gravity' must either be a single value for " <<
@@ -551,37 +552,37 @@ boost::shared_ptr<ObstaclesConfig> ConfigurationReader::parseObstaclesFile(
 				zRotation, rotationAngle;
 		if(boost::regex_match(line.c_str(), match,
 						fullObstacleRegex)){
-			x = std::atof(match[1].str().c_str());
-			y = std::atof(match[2].str().c_str());
-			z = std::atof(match[3].str().c_str());
-			xSize = std::atof(match[4].str().c_str());
-			ySize = std::atof(match[5].str().c_str());
-			zSize = std::atof(match[6].str().c_str());
-			density = std::atof(match[7].str().c_str());
-			xRotation = std::atof(match[8].str().c_str());
-			yRotation = std::atof(match[9].str().c_str());
-			zRotation = std::atof(match[10].str().c_str());
-			rotationAngle = std::atof(match[11].str().c_str());
+			x = parse_float(match[1].str());
+			y = parse_float(match[2].str());
+			z = parse_float(match[3].str());
+			xSize = parse_float(match[4].str());
+			ySize = parse_float(match[5].str());
+			zSize = parse_float(match[6].str());
+			density = parse_float(match[7].str());
+			xRotation = parse_float(match[8].str());
+			yRotation = parse_float(match[9].str());
+			zRotation = parse_float(match[10].str());
+			rotationAngle = parse_float(match[11].str());
 		} else {
 			xRotation = yRotation = zRotation = rotationAngle = 0.0;
 			if (boost::regex_match(line.c_str(), match, oldObstacleRegex)){
-				x = std::atof(match[1].str().c_str());
-				y = std::atof(match[2].str().c_str());
-				xSize = std::atof(match[3].str().c_str());
-				ySize = std::atof(match[4].str().c_str());
-				zSize = std::atof(match[5].str().c_str());
-				density = std::atof(match[6].str().c_str());
+				x = parse_float(match[1].str());
+				y = parse_float(match[2].str());
+				xSize = parse_float(match[3].str());
+				ySize = parse_float(match[4].str());
+				zSize = parse_float(match[5].str());
+				density = parse_float(match[6].str());
 
 				z = zSize/2;
 			} else if(boost::regex_match(line.c_str(), match,
 					noRotationObstacleRegex)){
-				x = std::atof(match[1].str().c_str());
-				y = std::atof(match[2].str().c_str());
-				z = std::atof(match[3].str().c_str());
-				xSize = std::atof(match[4].str().c_str());
-				ySize = std::atof(match[5].str().c_str());
-				zSize = std::atof(match[6].str().c_str());
-				density = std::atof(match[7].str().c_str());
+				x = parse_float(match[1].str());
+				y = parse_float(match[2].str());
+				z = parse_float(match[3].str());
+				xSize = parse_float(match[4].str());
+				ySize = parse_float(match[5].str());
+				zSize = parse_float(match[6].str());
+				density = parse_float(match[7].str());
 			} else {
 				std::cerr << "Error parsing line " << lineNum <<
 						" of obstacles file: '" << fileName << "'"
@@ -626,7 +627,7 @@ boost::shared_ptr<LightSourcesConfig> ConfigurationReader::parseLightSourcesFile
 		boost::cmatch match;
 		float x, y, z, intensity;
 		if(boost::regex_match(line.c_str(), match, fullRegex)){
-			intensity = std::atof(match[4].str().c_str());
+			intensity = parse_float(match[4].str());
 		} else {
 			intensity = 1.0;
 			if(!boost::regex_match(line.c_str(), match, noIntensityRegex)){
@@ -638,9 +639,9 @@ boost::shared_ptr<LightSourcesConfig> ConfigurationReader::parseLightSourcesFile
 				return boost::shared_ptr<LightSourcesConfig>();
 			}
 		}
-		x = std::atof(match[1].str().c_str());
-		y = std::atof(match[2].str().c_str());
-		z = std::atof(match[3].str().c_str());
+		x = parse_float(match[1].str());
+		y = parse_float(match[2].str());
+		z = parse_float(match[3].str());
 		coordinates.push_back(osg::Vec3(x, y, z));
 		intensities.push_back(intensity);
 

--- a/src/config/EvolverConfiguration.cpp
+++ b/src/config/EvolverConfiguration.cpp
@@ -34,6 +34,8 @@
 #include <boost/filesystem.hpp>
 
 #include "config/EvolverConfiguration.h"
+#include "utils/ParsingUtils.h"
+
 #include "PartList.h"
 
 namespace robogen {
@@ -59,8 +61,8 @@ bool parseBounds(std::string value, double &min, double &max) {
 				"\" does not match pattern <min>:<max>" << std::endl;
 		return false;
 	}
-	min = std::atof(match[1].first);
-	max = std::atof(match[2].first);
+	min = parse_double(match[1].str());
+	max = parse_double(match[2].str());
 	if (min > max) {
 		std::cerr << "supplied min " << min << " is greater than supplied max "
 				<< max << std::endl;
@@ -331,11 +333,11 @@ bool EvolverConfiguration::init(std::string configFileName) {
 		return false;
 	}
 	if(vm.count("brainSigma") > 0){
-		brainWeightSigma = atof(vm["brainSigma"].as<std::string>().c_str());
+		brainWeightSigma = parse_double(vm["brainSigma"].as<std::string>());
 		brainBiasSigma = brainWeightSigma;
 	} else if(vm.count("weightSigma") > 0 && vm.count("biasSigma") > 0) {
-		brainWeightSigma = atof(vm["weightSigma"].as<std::string>().c_str());
-		brainBiasSigma = atof(vm["biasSigma"].as<std::string>().c_str());
+		brainWeightSigma = parse_double(vm["weightSigma"].as<std::string>());
+		brainBiasSigma = parse_double(vm["biasSigma"].as<std::string>());
 	} else {
 		std::cerr << "Must supply either brainSigma or (weightSigma and biasSigma)"
 				<< " ( and sigmas for other brain params)" << std::endl;
@@ -385,8 +387,8 @@ bool EvolverConfiguration::init(std::string configFileName) {
 					"\" does not match pattern <min>:<max>" << std::endl;
 			return false;
 		}
-		minNumInitialParts = std::atof(match[1].first);
-		maxNumInitialParts = std::atof(match[2].first);
+		minNumInitialParts = parse_float(match[1].str());
+		maxNumInitialParts = parse_float(match[2].str());
 	}
 
 

--- a/src/evolution/representation/RobotRepresentation.cpp
+++ b/src/evolution/representation/RobotRepresentation.cpp
@@ -46,6 +46,8 @@
 #include "PartList.h"
 #include "utils/json2pb/json2pb.h"
 #include "utils/RobogenUtils.h"
+#include "utils/ParsingUtils.h"
+
 #include "brain/NeuralNetwork.h"
 
 #define VERIFY_ON_LOAD_TXT
@@ -211,7 +213,7 @@ bool robotTextFileReadWeightLine(std::ifstream &file, std::string &from,
 		fromIoId = std::atoi(match[2].first);
 		to.assign(match[3]);
 		toIoId = std::atoi(match[4].first);
-		value = std::atof(match[5].first);
+		value = parse_double(match[5].str());
 		return true;
 	} else {
 		// additional info if poor formatting, i.e. line not empty
@@ -300,7 +302,7 @@ bool robotTextFileReadParamsLine(std::ifstream &file, std::string &node,
 		std::vector<std::string> strs;
 		boost::split(strs, paramsString, boost::is_any_of(" "));
 		for (unsigned int i=0; i<strs.size(); i++) {
-			params.push_back(std::atof(strs[i].c_str()));
+			params.push_back(parse_double(strs[i]));
 		}
 		return true;
 	} else if (boost::regex_match(line.c_str(), match, biasRx)) {
@@ -311,7 +313,7 @@ bool robotTextFileReadParamsLine(std::ifstream &file, std::string &node,
 		node.assign(match[1]);
 		ioId = std::atoi(match[2].first);
 		type = NeuronRepresentation::SIGMOID;
-		params.push_back(std::atof(match[3].first));
+		params.push_back(parse_double(match[3].str()));
 		return true;
 	} else {
 		// additional info if poor formatting, i.e. line not empty

--- a/src/utils/ParsingUtils.h
+++ b/src/utils/ParsingUtils.h
@@ -1,0 +1,59 @@
+/*
+ * @(#) RobogenUtils.h   1.0   Feb 17, 2013
+ *
+ * Basil Huber (basil.huber@epfl.ch)
+ *
+ * The ROBOGEN Framework
+ * Copyright © 2012-2016 Andrea Maesani, Joshua Auerbach
+ *
+ * Laboratory of Intelligent Systems, EPFL
+ *
+ * This file is part of the ROBOGEN Framework.
+ *
+ * The ROBOGEN Framework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL)
+ * as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @(#) $Id$
+ */
+#ifndef PARSING_UTILS_H_
+#define PARSING_UTILS_H_
+
+#include <sstream>
+
+
+namespace robogen
+{
+	static inline float parse_float(const std::string& str)
+	{
+
+		float f = 0.0f;
+		std::istringstream istr(str);
+
+		istr >> f;
+
+		return f;
+	}
+
+
+	static inline double parse_double(const std::string& str)
+	{
+
+		double d = 0.0f;
+		std::istringstream istr(str);
+
+		istr >> d;
+
+		return d;
+	}
+}
+#endif /* PARSING_UTILS_H_ */


### PR DESCRIPTION
Replaced std::atof with ParsingUtils::parse_float and ParsingUtils::parse_double to avoid dependency on locale

This uses istringstream to parse the string to float which depends on the global locale compared to atof which depends on the local locale (see [here](http://stackoverflow.com/a/1333899)).

this fixes #53